### PR TITLE
Add `--skip-content-type-check` option for skipping check of content type of assets.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,5 +119,6 @@ func init() {
 	rootCmd.Flags().StringVarP(&sOpt.BinMatch, "bin-match", "", "", "regexp to match bin path in asset")
 	rootCmd.Flags().BoolVarP(&sOpt.Force, "force", "f", false, "enable force setup")
 	rootCmd.Flags().BoolVarP(&opt.Strict, "strict", "", false, "require strict match")
+	rootCmd.Flags().BoolVarP(&opt.SkipContentTypeCheck, "skip-content-type-check", "", false, "skip check content-type of assets")
 	rootCmd.Flags().BoolVarP(&verbose, "verbose", "", false, "show verbose log")
 }

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -51,11 +51,12 @@ var supportContentType = []string{
 const versionLatest = "latest"
 
 type AssetOption struct {
-	Match   string
-	Version string
-	OS      string
-	Arch    string
-	Strict  bool
+	Match                string
+	Version              string
+	OS                   string
+	Arch                 string
+	Strict               bool
+	SkipContentTypeCheck bool
 }
 
 func GetReleaseAsset(ctx context.Context, owner, repo string, opt *AssetOption) (*releaseAsset, fs.FS, error) {
@@ -133,7 +134,7 @@ func detectAsset(assets []*releaseAsset, opt *AssetOption) (*releaseAsset, error
 	}
 	assetScores := []*assetScore{}
 	for _, a := range assets {
-		if a.ContentType != "" && !contains(supportContentType, a.ContentType) {
+		if !opt.SkipContentTypeCheck && a.ContentType != "" && !contains(supportContentType, a.ContentType) {
 			slog.Info("Skip",
 				slog.String("name", a.Name),
 				slog.String("reason", "Unsupported content type"),

--- a/gh/gh.go
+++ b/gh/gh.go
@@ -134,7 +134,7 @@ func detectAsset(assets []*releaseAsset, opt *AssetOption) (*releaseAsset, error
 	}
 	assetScores := []*assetScore{}
 	for _, a := range assets {
-		if !opt.SkipContentTypeCheck && a.ContentType != "" && !contains(supportContentType, a.ContentType) {
+		if (opt == nil || !opt.SkipContentTypeCheck) && a.ContentType != "" && !contains(supportContentType, a.ContentType) {
 			slog.Info("Skip",
 				slog.String("name", a.Name),
 				slog.String("reason", "Unsupported content type"),


### PR DESCRIPTION
Add option to skip content type check because sometimes the content type of assets are incorrect.