### PR TITLE
ci: update CI workflow to include checksum verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,10 @@ jobs:
         uses: ./
         with:
           repo: k1LoW/tbls
+          version: v1.84.0
+          os: linux
+          arch: amd64
+          checksum: 83f35a07fd2a00c2aa360a47edca6d261f5208186911977eff39097151fc57d5
           force: true
           strict: true
           gh-setup-version: ${{ steps.latest_version.outputs.version }}

--- a/scripts/run-gh-setup.sh
+++ b/scripts/run-gh-setup.sh
@@ -34,5 +34,4 @@ if [ ! -z "${skip_content_type_check}" ]; then
     boolopts+=" --skip-content-type-check"
 fi
 
-# ${bin} --repo ${repo} --version=${version} --os=${os} --arch=${arch} --match=${match} --bin-dir=${bin_dir} --bin-match=${bin_match} --checksum=${checksum}${boolopts}
-${bin} --repo ${repo} --version=${version} --os=${os} --arch=${arch} --match=${match} --bin-dir=${bin_dir} --bin-match=${bin_match}${boolopts}
+${bin} --repo ${repo} --version=${version} --os=${os} --arch=${arch} --match=${match} --bin-dir=${bin_dir} --bin-match=${bin_match} --checksum=${checksum}${boolopts}


### PR DESCRIPTION
This pull request includes updates to the CI workflow and the `run-gh-setup.sh` script to ensure proper versioning and checksum validation.

Workflow updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR116-R119): Added `version`, `os`, `arch`, and `checksum` parameters to the job configuration to specify the version and ensure integrity of the binaries used.

Script updates:

* [`scripts/run-gh-setup.sh`](diffhunk://#diff-5981b12c44c0f708725ecc584156730f512cc3251628fc1c25423d9f5589eb7fL37-R37): Re-enabled the `checksum` parameter in the command to ensure that the binary integrity is verified during setup.