### PR TITLE
fix: stop using bufio.Scanner to parse release pages

### DIFF
--- a/gh/client.go
+++ b/gh/client.go
@@ -1,8 +1,6 @@
 package gh
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -148,11 +146,14 @@ func (c *client) getReleaseAssetsURLs(ctx context.Context, page int) ([]string, 
 	if err != nil {
 		return nil, err
 	}
-	scanner := bufio.NewScanner(bytes.NewReader(b))
-	scanner.Split(bufio.ScanLines)
+	return c.parseReleaseAssetsURLs(string(b)), nil
+}
+
+func (c *client) parseReleaseAssetsURLs(body string) []string {
 	urls := []string{}
-	for scanner.Scan() {
-		line := scanner.Text()
+	// Iterate the already buffered body instead of bufio.Scanner, which fails on the
+	// >64KB inline script lines the GitHub WebUI embeds.
+	for line := range strings.Lines(body) {
 		if strings.Contains(line, fmt.Sprintf("https://github.com/%s/%s/releases/expanded_assets/", c.owner, c.repo)) {
 			splitted := strings.Split(line, `src="`)
 			if len(splitted) == 2 {
@@ -161,10 +162,7 @@ func (c *client) getReleaseAssetsURLs(ctx context.Context, page int) ([]string, 
 			}
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return urls, nil
+	return urls
 }
 
 func (c *client) getReleaseAssetsViaURL(ctx context.Context, url string) ([]*releaseAsset, error) {
@@ -182,11 +180,14 @@ func (c *client) getReleaseAssetsViaURL(ctx context.Context, url string) ([]*rel
 	if err != nil {
 		return nil, err
 	}
-	scanner := bufio.NewScanner(bytes.NewReader(b))
-	scanner.Split(bufio.ScanLines)
+	return parseReleaseAssets(string(b)), nil
+}
+
+func parseReleaseAssets(body string) []*releaseAsset {
 	assets := []*releaseAsset{}
-	for scanner.Scan() {
-		line := scanner.Text()
+	// Iterate the already buffered body instead of bufio.Scanner, which fails on the
+	// >64KB inline script lines the GitHub WebUI embeds.
+	for line := range strings.Lines(body) {
 		if strings.Contains(line, "/download/") {
 			splitted := strings.Split(line, `href="`)
 			if len(splitted) == 2 {
@@ -201,10 +202,7 @@ func (c *client) getReleaseAssetsViaURL(ctx context.Context, url string) ([]*rel
 			}
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return assets, nil
+	return assets
 }
 
 func (c *client) getReleaseAssetsWithAPI(ctx context.Context, opt *AssetOption) ([]*releaseAsset, error) {

--- a/gh/client.go
+++ b/gh/client.go
@@ -150,11 +150,12 @@ func (c *client) getReleaseAssetsURLs(ctx context.Context, page int) ([]string, 
 }
 
 func (c *client) parseReleaseAssetsURLs(body string) []string {
+	prefix := fmt.Sprintf("https://github.com/%s/%s/releases/expanded_assets/", c.owner, c.repo)
 	urls := []string{}
 	// Iterate the already buffered body instead of bufio.Scanner, which fails on the
 	// >64KB inline script lines the GitHub WebUI embeds.
 	for line := range strings.Lines(body) {
-		if strings.Contains(line, fmt.Sprintf("https://github.com/%s/%s/releases/expanded_assets/", c.owner, c.repo)) {
+		if strings.Contains(line, prefix) {
 			splitted := strings.Split(line, `src="`)
 			if len(splitted) == 2 {
 				splitted2 := strings.Split(splitted[1], `"`)

--- a/gh/client_test.go
+++ b/gh/client_test.go
@@ -1,8 +1,13 @@
 package gh
 
 import (
+	"bufio"
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGetReleaseAssetsWithoutAPI(t *testing.T) {
@@ -28,5 +33,50 @@ func TestGetReleaseAssetsWithoutAPI(t *testing.T) {
 		if len(assets) == 0 {
 			t.Error("want assets")
 		}
+	}
+}
+
+// longLine is longer than bufio.MaxScanTokenSize. The GitHub WebUI embeds such lines
+// (inline scripts) in the release pages, and they must not stop the parsing.
+var longLine = fmt.Sprintf(`<script type="application/json">%s</script>`, strings.Repeat("x", bufio.MaxScanTokenSize))
+
+func TestParseReleaseAssetsURLs(t *testing.T) {
+	c := &client{owner: "k1LoW", repo: "octocov"}
+	body := strings.Join([]string{
+		longLine,
+		`  <include-fragment src="https://github.com/k1LoW/octocov/releases/expanded_assets/v0.75.12" data-test-selector="lazy-assets">`,
+		`  <include-fragment src="https://github.com/k1LoW/octocov/releases/expanded_assets/v0.75.11" data-test-selector="lazy-assets">`,
+		`  <include-fragment src="https://github.com/k1LoW/other/releases/expanded_assets/v1.0.0">`,
+	}, "\n")
+	got := c.parseReleaseAssetsURLs(body)
+	want := []string{
+		"https://github.com/k1LoW/octocov/releases/expanded_assets/v0.75.12",
+		"https://github.com/k1LoW/octocov/releases/expanded_assets/v0.75.11",
+	}
+	if diff := cmp.Diff(got, want, nil); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestParseReleaseAssets(t *testing.T) {
+	body := strings.Join([]string{
+		longLine,
+		`        <a href="/k1LoW/octocov/releases/download/v0.75.12/octocov_v0.75.12_darwin_arm64.zip" rel="nofollow" class="Truncate">`,
+		`        <a href="/k1LoW/octocov/releases/download/v0.75.12/checksums.txt" rel="nofollow" class="Truncate">`,
+		`        <a href="/k1LoW/octocov/releases/tag/v0.75.12">v0.75.12</a>`,
+	}, "\n")
+	got := parseReleaseAssets(body)
+	want := []*releaseAsset{
+		{
+			Name:        "octocov_v0.75.12_darwin_arm64.zip",
+			DownloadURL: "https://github.com/k1LoW/octocov/releases/download/v0.75.12/octocov_v0.75.12_darwin_arm64.zip",
+		},
+		{
+			Name:        "checksums.txt",
+			DownloadURL: "https://github.com/k1LoW/octocov/releases/download/v0.75.12/checksums.txt",
+		},
+	}
+	if diff := cmp.Diff(got, want, nil); diff != "" {
+		t.Error(diff)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k1LoW/gh-setup
 
-go 1.25.0
+go 1.25.12
 
 require (
 	github.com/cli/go-gh/v2 v2.13.0


### PR DESCRIPTION
The WebUI fallback (used when the API is not available) failed with `bufio.Scanner: token too long` because the GitHub release pages embed inline script lines over 64KB, which exceeds `bufio.MaxScanTokenSize`. Raising the scanner buffer would just move the limit, so the response body, which is already fully buffered by `io.ReadAll`, is now iterated with `strings.Lines` instead.

- Replace `bufio.Scanner` with `strings.Lines` in `getReleaseAssetsURLs` / `getReleaseAssetsViaURL`
- Extract the HTML parsing into `parseReleaseAssetsURLs` / `parseReleaseAssets` and add tests that feed a line longer than `bufio.MaxScanTokenSize`

Verified with `k1LoW/octocov` `v0.75.12` (the reported case): it fails with `bufio.Scanner: token too long` before this change and returns all 15 assets after it.

Fix: https://github.com/k1LoW/gh-setup/issues/202